### PR TITLE
can not pull unapproved requests from postman, and when it is tried o…

### DIFF
--- a/Tabloid-Fullstack/Controllers/PostController.cs
+++ b/Tabloid-Fullstack/Controllers/PostController.cs
@@ -14,10 +14,12 @@ namespace Tabloid_Fullstack.Controllers
     {
 
         private IPostRepository _repo;
+        private IUserProfileRepository _userRepo;
 
-        public PostController(IPostRepository repo)
+        public PostController(IPostRepository repo, IUserProfileRepository userRepo)
         {
             _repo = repo;
+            _userRepo = userRepo;
         }
 
 
@@ -32,7 +34,8 @@ namespace Tabloid_Fullstack.Controllers
         public IActionResult GetById(int id)
         {
             var post = _repo.GetById(id);
-            if (post == null || post.IsApproved == false)
+            var user = _userRepo.GetByUserProfileId(post.UserProfileId);
+            if (post == null || post.IsApproved)
             {
                 return NotFound();
             }

--- a/Tabloid-Fullstack/Controllers/PostController.cs
+++ b/Tabloid-Fullstack/Controllers/PostController.cs
@@ -32,7 +32,7 @@ namespace Tabloid_Fullstack.Controllers
         public IActionResult GetById(int id)
         {
             var post = _repo.GetById(id);
-            if (post == null)
+            if (post == null || post.IsApproved == false)
             {
                 return NotFound();
             }

--- a/Tabloid-Fullstack/Repositories/IUserProfileRepository.cs
+++ b/Tabloid-Fullstack/Repositories/IUserProfileRepository.cs
@@ -6,5 +6,6 @@ namespace Tabloid_Fullstack.Repositories
     {
         void Add(UserProfile userProfile);
         UserProfile GetByFirebaseUserId(string firebaseUserId);
+        UserProfile GetByUserProfileId(int id);
     }
 }

--- a/Tabloid-Fullstack/Repositories/UserProfileRepository.cs
+++ b/Tabloid-Fullstack/Repositories/UserProfileRepository.cs
@@ -27,6 +27,13 @@ namespace Tabloid_Fullstack.Repositories
 
         }
 
+        public UserProfile GetByUserProfileId(int id)
+        {
+            UserProfile user = _context.UserProfile
+                .FirstOrDefault(uid => uid.Id == id);
+            return user;
+        }
+
         public void Add(UserProfile userProfile)
         {
             _context.Add(userProfile);

--- a/Tabloid-Fullstack/client/src/pages/PostDetails.js
+++ b/Tabloid-Fullstack/client/src/pages/PostDetails.js
@@ -1,19 +1,27 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { toast } from "react-toastify";
 import { Jumbotron } from "reactstrap";
 import PostReactions from "../components/PostReactions";
 import formatDate from "../utils/dateFormatter";
 import "./PostDetails.css";
+import  { UserProfileContext } from '../providers/UserProfileProvider';
 
 const PostDetails = () => {
   const { postId } = useParams();
   const [post, setPost] = useState();
   const [reactionCounts, setReactionCounts] = useState([]);
+  const { getToken } = useContext(UserProfileContext);
   const history = useHistory();
 
   useEffect(() => {
-    fetch(`/api/post/${postId}`)
+    return getToken().then((token) =>
+    fetch(`/api/post/${postId}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    })
       .then((res) => {
         if (res.status === 404) {
           toast.error("This isn't the post you're looking for");
@@ -27,7 +35,7 @@ const PostDetails = () => {
           setPost(data ? data.post : null);
           setReactionCounts(data.reactionCounts);
         }
-      });
+      }));
   }, [postId]);
 
   if (!post) return null;

--- a/Tabloid-Fullstack/client/src/pages/PostDetails.js
+++ b/Tabloid-Fullstack/client/src/pages/PostDetails.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useHistory } from "react-router-dom";
 import { toast } from "react-toastify";
 import { Jumbotron } from "reactstrap";
 import PostReactions from "../components/PostReactions";
@@ -10,19 +10,23 @@ const PostDetails = () => {
   const { postId } = useParams();
   const [post, setPost] = useState();
   const [reactionCounts, setReactionCounts] = useState([]);
+  const history = useHistory();
 
   useEffect(() => {
     fetch(`/api/post/${postId}`)
       .then((res) => {
         if (res.status === 404) {
           toast.error("This isn't the post you're looking for");
+          history.push("/explore")
           return;
         }
         return res.json();
       })
       .then((data) => {
-        setPost(data.post);
-        setReactionCounts(data.reactionCounts);
+        if(data){
+          setPost(data ? data.post : null);
+          setReactionCounts(data.reactionCounts);
+        }
       });
   }, [postId]);
 


### PR DESCRIPTION
…n client side it pushes you back to the explore pages to view posts

# Description
1. Made the change to the back-end so you can not view an unapproved post from Postman/Endpoint
2. When you try to view an unapproved post on the front-end it will push you back to the explore page to view posts and let you know the post was not found.


Fixes # (issue)
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
# Testing Instructions
Login view a post and then change the route parameter to /4 which is a unapproved post. It should push you to the explore page.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works