### PR TITLE
admin can create new tag

### DIFF
--- a/Tabloid-Fullstack/client/src/components/ApplicationViews.js
+++ b/Tabloid-Fullstack/client/src/components/ApplicationViews.js
@@ -24,7 +24,7 @@ const ApplicationViews = () => {
         {isLoggedIn ? <PostDetails /> : <Redirect to="/login" />}
       </Route>
       <Route path="/tags">
-        {isLoggedIn && isAdmin() ? <TagManager /> : !isLoggedIn ? <Redirect to="/login" /> : <Redirect to="/" />}
+        {isLoggedIn && isAdmin() ? <TagManager /> : !isLoggedIn ? <Redirect to="/login" /> : <Redirect to="/notfound" />}
       </Route>
       <Route path="/categories">
         {isLoggedIn && JSON.parse(localStorage.getItem("userProfile")).userTypeId === 1? <CategoryManager /> : <Redirect to="/notfound" />}


### PR DESCRIPTION
# Description
As an admin I would like to be able to create a new Tag so that I can give authors the ability to better classify their posts.

Given an admin is on the Tag list page
When they enter a Tag name and click the submit button
Then the Tag should be added to the database
And the list should refresh

NOTE whatever API endpoint is created to support this feature should only be accessible to admin users. Any other user attempting to access this endpoint should receive either a 404 or 401 response.
## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
- sign in as admin
- go to tag in navbar
- create new tag and save it
- it should add to the list in alphabetical order
NEXT
- sign in as author, rather than admin
- put /tags in the url
- you should get a 404 message
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works